### PR TITLE
Implement ProjectTree class with CLI and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,32 @@ Run the CLI:
 ```bash
 python -m mcp_project
 ```
+
+## Development workflow
+
+Active work happens on the `dev` branch. Changes are merged into `main` when they are ready for release.
+
+## Directory layout
+
+- `mcp_project/` – source code for the package.
+- `requirements.txt` – project dependencies.
+- `pyproject.toml` – build configuration.
+- `tests/` – unit tests.
+
+### Show the project tree
+
+Display the folder structure using:
+
+```bash
+python -m mcp_project.tree
+# or
+python -m mcp_project tree
+```
+
+### Run tests
+
+Execute the test suite with:
+
+```bash
+python -m pytest
+```

--- a/mcp_project/__init__.py
+++ b/mcp_project/__init__.py
@@ -1,5 +1,6 @@
 """MCP Project example package."""
 
-__all__ = ["main"]
+__all__ = ["main", "ProjectTree"]
 
 from .cli import main
+from .tree import ProjectTree

--- a/mcp_project/cli.py
+++ b/mcp_project/cli.py
@@ -1,5 +1,28 @@
-def main():
-    print("Hello from MCP PROJECT")
+"""Simple command line interface."""
+
+from __future__ import annotations
+
+import argparse
+from typing import List, Optional
+
+from .tree import ProjectTree
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    """Run the CLI with optional arguments."""
+    parser = argparse.ArgumentParser(description="MCP PROJECT CLI")
+    parser.add_argument(
+        "command",
+        nargs="?",
+        default="hello",
+        help="Choose 'tree' to show directories or leave empty for greeting",
+    )
+    args = parser.parse_args(argv)
+
+    if args.command == "tree":
+        ProjectTree().display()
+    else:
+        print("Hello from MCP PROJECT")
 
 if __name__ == "__main__":
     main()

--- a/mcp_project/tree.py
+++ b/mcp_project/tree.py
@@ -1,0 +1,53 @@
+"""Utilities to inspect project directories."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List
+
+
+class ProjectTree:
+    """Collect and display folder structures.
+
+    The class walks through the file system starting from ``root_path`` and
+    stores a simple text representation. Think of it like drawing a map of all
+    the files and folders so you can quickly see what is inside.
+    """
+
+    def __init__(self, root_path: str = ".") -> None:
+        # ``root_path`` is where the search begins. By default it uses the
+        # current directory. ``Path`` helps us work with filesystem paths in a
+        # platform-independent way.
+        self.root_path: Path = Path(root_path)
+
+    def build_tree(self) -> List[str]:
+        """Return a list of lines describing the directory tree."""
+        lines: List[str] = []
+        # ``os.walk`` goes through every folder and file starting at
+        # ``root_path``. It's like exploring every branch of a tree to list
+        # everything inside.
+        for folder, subfolders, files in os.walk(self.root_path):
+            # ``relative_to`` computes the path from ``root_path`` to the
+            # current ``folder``. The number of parts tells us the depth so we
+            # can indent accordingly.
+            depth = len(Path(folder).relative_to(self.root_path).parts)
+            indent = "    " * depth
+            lines.append(f"{indent}{Path(folder).name}/")
+            for file_name in sorted(files):
+                lines.append(f"{indent}    {file_name}")
+        return lines
+
+    def display(self) -> None:
+        """Print the tree line by line."""
+        for line in self.build_tree():
+            print(line)
+
+
+def main() -> None:
+    """Entry point for ``python -m mcp_project.tree``."""
+    ProjectTree().display()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,0 +1,14 @@
+import os
+from pathlib import Path
+from mcp_project.tree import ProjectTree
+
+
+def test_build_tree(tmp_path: Path) -> None:
+    # Create sample directory structure
+    (tmp_path / "dirA").mkdir()
+    (tmp_path / "dirA" / "file.txt").write_text("hi")
+
+    tree = ProjectTree(str(tmp_path))
+    lines = tree.build_tree()
+    assert any("dirA/" in line for line in lines)
+    assert any("file.txt" in line for line in lines)


### PR DESCRIPTION
## Summary
- document development workflow and layout in README
- add typed ProjectTree class to show directory tree
- expose class in package init and update CLI to support `tree` command
- add unit test for ProjectTree

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872c5d734108323844d87524cd64220