### PR TITLE
Add ProjectTree module and CLI entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ python -m mcp_project.tree
 python -m mcp_project tree
 ```
 
+### Use ``ProjectTree`` in your code
+
+You can also build the listing programmatically:
+
+```python
+from mcp_project import ProjectTree
+
+tree = ProjectTree(".")
+for line in tree.build_tree():
+    print(line)
+```
+
 ### Run tests
 
 Execute the test suite with:

--- a/mcp_project/__init__.py
+++ b/mcp_project/__init__.py
@@ -3,4 +3,4 @@
 __all__ = ["main", "ProjectTree"]
 
 from .cli import main
-from .tree import ProjectTree
+from .project_tree import ProjectTree

--- a/mcp_project/__main__.py
+++ b/mcp_project/__main__.py
@@ -1,0 +1,8 @@
+"""Allow running ``python -m mcp_project`` directly."""
+
+from __future__ import annotations
+
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/mcp_project/project_tree.py
+++ b/mcp_project/project_tree.py
@@ -1,0 +1,49 @@
+"""Helpers to inspect project directories with explanations for beginners."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List
+
+
+class ProjectTree:
+    """Collect and display folder structures.
+
+    The class walks through the file system starting from ``root_path`` and
+    stores a simple text representation. Think of it like drawing a map of all
+    the files and folders so you can quickly see what is inside.
+    """
+
+    def __init__(self, root_path: str = ".") -> None:
+        # ``root_path`` is where the search begins. By default it uses the
+        # current directory. ``Path`` helps us work with filesystem paths in a
+        # platform-independent way.
+        self.root_path: Path = Path(root_path)
+
+    def build_tree(self) -> List[str]:
+        """Return a list of lines describing the directory tree."""
+        lines: List[str] = []
+        # ``os.walk`` goes through every folder and file starting at
+        # ``root_path``. It's like exploring every branch of a tree to list
+        # everything inside.
+        for folder, subfolders, files in os.walk(self.root_path):
+            # ``relative_to`` computes the path from ``root_path`` to the
+            # current ``folder``. The number of parts tells us the depth so we
+            # can indent accordingly.
+            depth = len(Path(folder).relative_to(self.root_path).parts)
+            indent = "    " * depth
+            lines.append(f"{indent}{Path(folder).name}/")
+            for file_name in sorted(files):
+                lines.append(f"{indent}    {file_name}")
+        return lines
+
+    def display(self) -> None:
+        """Print the tree line by line."""
+        for line in self.build_tree():
+            print(line)
+
+
+# ``os.walk`` is part of Python's standard library. If you want to dive
+# deeper into how it works, check out the official docs:
+# https://docs.python.org/3/library/os.html#os.walk

--- a/mcp_project/tree.py
+++ b/mcp_project/tree.py
@@ -1,47 +1,12 @@
-"""Utilities to inspect project directories."""
+"""Compatibility wrapper for ``ProjectTree``.
+
+This module keeps the old import path working while the real
+implementation lives in :mod:`mcp_project.project_tree`.
+"""
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
-from typing import List
-
-
-class ProjectTree:
-    """Collect and display folder structures.
-
-    The class walks through the file system starting from ``root_path`` and
-    stores a simple text representation. Think of it like drawing a map of all
-    the files and folders so you can quickly see what is inside.
-    """
-
-    def __init__(self, root_path: str = ".") -> None:
-        # ``root_path`` is where the search begins. By default it uses the
-        # current directory. ``Path`` helps us work with filesystem paths in a
-        # platform-independent way.
-        self.root_path: Path = Path(root_path)
-
-    def build_tree(self) -> List[str]:
-        """Return a list of lines describing the directory tree."""
-        lines: List[str] = []
-        # ``os.walk`` goes through every folder and file starting at
-        # ``root_path``. It's like exploring every branch of a tree to list
-        # everything inside.
-        for folder, subfolders, files in os.walk(self.root_path):
-            # ``relative_to`` computes the path from ``root_path`` to the
-            # current ``folder``. The number of parts tells us the depth so we
-            # can indent accordingly.
-            depth = len(Path(folder).relative_to(self.root_path).parts)
-            indent = "    " * depth
-            lines.append(f"{indent}{Path(folder).name}/")
-            for file_name in sorted(files):
-                lines.append(f"{indent}    {file_name}")
-        return lines
-
-    def display(self) -> None:
-        """Print the tree line by line."""
-        for line in self.build_tree():
-            print(line)
+from .project_tree import ProjectTree
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add `project_tree.py` and keep `tree.py` as compatibility wrapper
- expose `ProjectTree` from `mcp_project` package
- allow running the CLI via `python -m mcp_project`
- document how to instantiate and call `ProjectTree`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872cb70d0248323875ebfd190e6f33b