### PR TITLE
Add httpx constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ into `main`.
   python -m pip install -e .
   ```
 
+- The library `httpx` must be installed with a version **below** `0.27`:
+
+  ```bash
+  python -m pip install "httpx<0.27"
+  ```
+
 - Show the directory tree of the current folder:
 
   ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ requires-python = ">=3.11"
 dependencies = [
     "pytest==8.4.0",
     "requests==2.32.4",
-    "arxiv"  # added the missing dependency
+    "arxiv",  # added the missing dependency
+    "httpx<0.27",  # restrict to versions before 0.27 for server compatibility
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- restrict `httpx` to `<0.27` in the `pyproject`
- mention the version pin in the README

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876af0318308323aa0743d0b95e41de