### PR TITLE
Add mcp-server command with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ into `main`.
   python -m pytest
   ```
 
+- Launch the example API server:
+
+  ```bash
+  mcp-server
+  ```
+
 For a tour of the folder layout see `docs/01_project_structure.md`.
 For step-by-step validation instructions see `docs/05_validationGuide.md`.
 

--- a/mcp_server/__main__.py
+++ b/mcp_server/__main__.py
@@ -1,0 +1,25 @@
+"""Entry point for launching the API with ``python -m mcp_server`` or ``mcp-server``."""
+
+# ``uvicorn`` is the lightweight web server that will host our FastAPI app.
+# You can picture it as the engine of a car: once it starts, the application
+# begins responding to requests.
+import uvicorn
+
+# Import the FastAPI ``app`` defined in ``app.py``. This is the web application
+# we want ``uvicorn`` to run.
+from .app import app
+
+
+def main() -> None:
+    """Start the development server.
+
+    The function below boots up ``uvicorn`` so the API becomes reachable. It's
+    similar to turning on a lamp: once switched on, it keeps shining until we
+    turn it off.
+    """
+    uvicorn.run(app, host="127.0.0.1", port=8000)
+
+
+if __name__ == "__main__":
+    # Running the module directly should behave the same as calling ``main``.
+    main()

--- a/mcp_server/app.py
+++ b/mcp_server/app.py
@@ -1,0 +1,18 @@
+"""A tiny FastAPI application used for testing the server entry point."""
+
+# Import the FastAPI class. Think of this as the blueprint for our web server.
+from fastapi import FastAPI
+
+# Create the application instance. It's like opening the doors of a new shop
+# where clients will come in to interact.
+app = FastAPI()
+
+
+@app.get("/")
+def read_root() -> dict[str, str]:
+    """Return a basic health message.
+
+    This is comparable to a receptionist saying "hello" to confirm the shop
+    is open for business.
+    """
+    return {"status": "ok"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,13 @@ dependencies = [
     "requests==2.32.4",
     "arxiv",  # added the missing dependency
     "httpx<0.27",  # restrict to versions before 0.27 for server compatibility
+    "fastapi",  # lightweight web framework used for the example API
+    "uvicorn",  # ASGI server needed to run the application
 ]
 
 [project.scripts]
 mcp-project = "mcp_project.cli:main"
+mcp-server = "mcp_server.__main__:main"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/test_server_script.py
+++ b/tests/test_server_script.py
@@ -1,0 +1,30 @@
+"""Tests for the ``mcp-server`` entry point."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+
+def test_server_starts() -> None:
+    """Ensure the server process starts and can be terminated.
+
+    We spawn the process in the background much like turning on a kitchen timer
+    and then quickly checking that it is ticking before stopping it.
+    """
+    process = subprocess.Popen(
+        [sys.executable, "-m", "mcp_server"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        # Give the server a moment to boot up.
+        time.sleep(1)
+        # If ``poll`` returns ``None``, the process is still running.
+        assert process.poll() is None
+    finally:
+        # Cleanly stop the server after the check.
+        process.terminate()
+        process.wait(timeout=5)
+


### PR DESCRIPTION
## Summary
- create a simple FastAPI app under `mcp_server`
- add a `main` function calling `uvicorn.run`
- expose the command via `mcp-server` entry point
- document how to launch the API
- test that the server process starts

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876b0780dd08323ab20d31e2180f805